### PR TITLE
Remove redundant cask directives

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,7 +1,3 @@
-(package "terminal-here" "0.1" "Run an external terminal in current directory")
-
-(files "terminal-here.el")
-
 ;; Tell Cask to add package information to this file (so that we can have a
 ;; single file package).
 (package-file "terminal-here.el")


### PR DESCRIPTION
Using `package-file` means the removed directives were unnecessary.