### PR TITLE
Find executable for a terminal

### DIFF
--- a/terminal-here.el
+++ b/terminal-here.el
@@ -41,8 +41,10 @@
     (list "cmd.exe" "/C" "start" "cmd.exe"))
 
    ;; Probably X11!
-   (t '("x-terminal-emulator"))))
-
+   (t (list (cl-some (lambda (executable)
+                       (executable-find executable))
+                     '("x-terminal-emulator" "sl" "urxvt" "gnome-terminal"
+                       "konsole" "xterm"))))))
 
 (defcustom terminal-here-terminal-command
   #'terminal-here-default-terminal-command


### PR DESCRIPTION
* terminal-here.el (terminal-here-default-terminal-command): Find
executable for terminal.

GuixSD doesn't have `x-terminal-emulator`.  I'm not sure, but `x-terminal-emulator` exist only in systems which have `update-alternatives` program.  I'll try to fix tests if you agree with a patch.