### PR TITLE
Replace ‘list’ with ‘'’ in terminal-here-default-terminal-command

### DIFF
--- a/terminal-here.el
+++ b/terminal-here.el
@@ -34,11 +34,11 @@
   "Pick a good default command to use for DIR."
   (cond
    ((eq system-type 'darwin)
-    (list "open" "-a" "Terminal.app" "."))
+    '("open" "-a" "Terminal.app" "."))
 
    ;; From http://stackoverflow.com/a/13509208/874671
    ((memq system-type '(windows-nt ms-dos cygwin))
-    (list "cmd.exe" "/C" "start" "cmd.exe"))
+    '("cmd.exe" "/C" "start" "cmd.exe"))
 
    ;; Probably X11!
    (t '("x-terminal-emulator"))))


### PR DESCRIPTION
* terminal-here.el (terminal-here-default-terminal-command): Replace
‘list’ with ‘'’.

Arguments don't need to be evaluated, so lets just quote them.