### PR TITLE
Add launch terminal with multiplexer functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ If the default command doesn't launch your preferred terminal you can set
 arguments (e.g. `(list "my-terminal" "--foo")`)
 or a function which takes a directory and returns such a list.
 
+If you have a terminal multiplexer `screen` or `tmux` you could start
+them with <kbd>M-x terminal-here-launch-multiplexer</kbd> in current
+working directory or in a project with
+<kbd>M-x terminal-here-project-launch-multiplexer</kbd>.
+
 Recommended keybindings:
 
 ```


### PR DESCRIPTION
New functions ‘terminal-here-project-launch-multiplexer’ and
‘terminal-here-launch-multiplexer’ to launch a terminal with a
‘screen’ or ‘tmux’ multiplexer.

* terminal-here.el (terminal-here-multiplexer,
terminal-here-multiplexers, terminal-here-multiplexer-new-session,
terminal-here-multiplexer-flags, terminal-here-multiplexer-session):
New variables.
(terminal-here-multiplexer-command, terminal-here-launch-multiplexer,
terminal-here-project-launch-multiplexer,
terminal-here-find-executable): New functions.
(terminal-here--ssh-command, terminal-here--term-command,
terminal-here-launch-in-directory, terminal-here-launch,
terminal-here-project-launch)[multiplexer]: New optional argument.
(terminal-here-not-null-symbol): New macro.

Succeeds all tests https://travis-ci.org/wigust/terminal-here/builds/341969206