### PR TITLE
Use tramp to parse directory

### DIFF
--- a/terminal-here.el
+++ b/terminal-here.el
@@ -80,7 +80,8 @@ Typically this is -e, gnome-terminal uses -x."
 
 (defun terminal-here--parse-ssh-dir (dir)
   (when (string-prefix-p "/ssh:" dir)
-    (cdr (split-string dir ":"))))
+    (with-parsed-tramp-file-name dir nil
+      (list (if user (concat user "@" host) host) localname))))
 
 (defun terminal-here--ssh-command (remote dir)
   (append (terminal-here--term-command "") (list terminal-here-command-flag "ssh" "-t" remote "cd" dir "&&" "exec" "$SHELL" "-")))

--- a/test/terminal-here-test.el
+++ b/test/terminal-here-test.el
@@ -103,6 +103,7 @@
   (should (equal (terminal-here--parse-ssh-dir "/ssh:buildbot:/home/buildbot/") (list "buildbot" "/home/buildbot/")))
   (should (equal (terminal-here--parse-ssh-dir "/ssh:david@pi:/home/pi/") (list "david@pi" "/home/pi/")))
   (should (equal (terminal-here--parse-ssh-dir "/ssh:root@192.168.0.1:/etc/hosts") (list "root@192.168.0.1" "/etc/hosts")))
+  (should (equal (terminal-here--parse-ssh-dir "/ssh:myhost:/home/me/colon:dir") (list "myhost" "/home/me/colon:dir")))
 
   (should-not (terminal-here--parse-ssh-dir "/home/buildbot/"))
   (should-not (terminal-here--parse-ssh-dir "/ssh/foo/bar")))


### PR DESCRIPTION
This fixes parsing of remote file names containing colons.

I also added a `ert-test`.