### PR TITLE
Fix XFCE terminal name

### DIFF
--- a/terminal-here.el
+++ b/terminal-here.el
@@ -45,17 +45,17 @@
      ;; Try to guess from the wide range of "standard" environment variables!
      ;; Based on xdg_util.cc.
      ((equal xdg-current-desktop "Enlightenment") 'terminology)
-     ((equal xdg-current-desktop "Unity") 'gnome-terminal)
      ((equal xdg-current-desktop "GNOME") 'gnome-terminal)
      ((equal xdg-current-desktop "KDE") 'konsole)
-     ((equal desktop-session "enlightenment") 'terminology)
      ((equal xdg-current-desktop "LXQt") 'qterminal)
+     ((equal xdg-current-desktop "Unity") 'gnome-terminal)
+     ((equal desktop-session "enlightenment") 'terminology)
      ((equal desktop-session "gnome") 'gnome-terminal)
-     ((equal desktop-session "mate") 'gnome-terminal)
-     ((equal desktop-session "kde4") 'konsole)
-     ((equal desktop-session "kde-plasma") 'konsole)
      ((equal desktop-session "kde") 'konsole)
+     ((equal desktop-session "kde-plasma") 'konsole)
+     ((equal desktop-session "kde4") 'konsole)
      ((equal desktop-session "lxqt") 'qterminal)
+     ((equal desktop-session "mate") 'gnome-terminal)
      ((equal desktop-session "xubuntu") 'xfce-terminal)
      ((string-match-p (regexp-quote "xfce") desktop-session) 'xfce-terminal)
 

--- a/terminal-here.el
+++ b/terminal-here.el
@@ -56,8 +56,8 @@
      ((equal desktop-session "kde4") 'konsole)
      ((equal desktop-session "lxqt") 'qterminal)
      ((equal desktop-session "mate") 'gnome-terminal)
-     ((equal desktop-session "xubuntu") 'xfce-terminal)
-     ((string-match-p (regexp-quote "xfce") desktop-session) 'xfce-terminal)
+     ((equal desktop-session "xubuntu") 'xfce4-terminal)
+     ((string-match-p (regexp-quote "xfce") desktop-session) 'xfce4-terminal)
 
      ;; We've failed, hopefully we're on a Debian-based OS so that we can use this
      ((executable-find "x-terminal-emulator") 'x-terminal-emulator))))

--- a/terminal-here.el
+++ b/terminal-here.el
@@ -49,6 +49,7 @@
      ((equal xdg-current-desktop "KDE") 'konsole)
      ((equal xdg-current-desktop "LXQt") 'qterminal)
      ((equal xdg-current-desktop "Unity") 'gnome-terminal)
+     ((equal xdg-current-desktop "XFCE") 'xfce4-terminal)
      ((equal desktop-session "enlightenment") 'terminology)
      ((equal desktop-session "gnome") 'gnome-terminal)
      ((equal desktop-session "kde") 'konsole)


### PR DESCRIPTION
- Sort desktops names
- Fix XFCE terminal name
- Allow XFCE in `$XDG_CURRENT_DESKTOP`