### PR TITLE
Fix tests: Mock executable-find for kgx/gnome-terminal respectively

### DIFF
--- a/test/terminal-here-test.el
+++ b/test/terminal-here-test.el
@@ -42,6 +42,8 @@
 (ert-deftest linux-default-command-gnome-de ()
   (with-mock
    (stub getenv => "GNOME")
+   (mock (executable-find "gnome-terminal") => "/bin/gnome-terminal")
+   (mock (executable-find "kgx"))
    (let ((system-type 'gnu/linux))
      (custom-reevaluate-setting 'terminal-here-terminal-command)
      (custom-reevaluate-setting 'terminal-here-linux-terminal-command)
@@ -51,7 +53,8 @@
 (ert-deftest linux-default-command-gnome-de-with-gnome-console ()
   (with-mock
    (stub getenv => "GNOME")
-   (stub executable-find => "/bin/kgx")
+   (mock (executable-find "gnome-terminal"))
+   (mock (executable-find "kgx") => "/bin/kgx")
    (let ((system-type 'gnu/linux))
      (custom-reevaluate-setting 'terminal-here-terminal-command)
      (custom-reevaluate-setting 'terminal-here-linux-terminal-command)


### PR DESCRIPTION
On my system ` linux-default-command-gnome-de`  fails with:

```
Test linux-default-command-gnome-de condition:
    (ert-test-failed
     ((should
       (equal
	(terminal-here--get-terminal-command "adir")
	'("gnome-terminal")))
      :form
      (equal
       ("kgx")
       ("gnome-terminal"))
      :value nil :explanation
      (list-elt 0
		(arrays-of-different-length 3 14 "kgx" "gnome-terminal" first-mismatch-at 0))))
```